### PR TITLE
TP-2563-fix-healthie-long-text-form-field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/awell-sdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "packageManager": "yarn@4.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/awellFormResponseToHealthieFormAnswers.test.ts
+++ b/src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/awellFormResponseToHealthieFormAnswers.test.ts
@@ -21,7 +21,7 @@ describe('awellFormResponseToHealthieFormAnswers', () => {
       { custom_module_id: 'short_text', answer: 'A short answer' },
       {
         custom_module_id: 'long_text',
-        answer: `\\u003cp\\u003eA long text\\u003c/p\\u003e\\u003cp\\u003eNew paragraph\\u003c/p\\u003e`,
+        answer: `<p>A long text</p><p>New paragraph</p>`,
       },
       { custom_module_id: 'phone', answer: '+32476581696' },
     ])

--- a/src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/awellFormResponseToHealthieFormAnswers.ts
+++ b/src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/awellFormResponseToHealthieFormAnswers.ts
@@ -37,8 +37,8 @@ export const getAnswerInHealthieFormat = (
     case 'NUMBER':
       return String(questionResponse.value)
     case 'LONG_TEXT': {
-      const { escapedHtml } = getLongTextAnswer(questionResponse.value)
-      return escapedHtml
+      const { html } = getLongTextAnswer(questionResponse.value)
+      return html
     }
     case 'MULTIPLE_CHOICE':
       return getSingleSelectAnswer(questionDefinition, questionResponse)

--- a/src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/utils/getLongTextAnswer/getLongTextAnswer.ts
+++ b/src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/utils/getLongTextAnswer/getLongTextAnswer.ts
@@ -6,6 +6,9 @@
  * where paragraphs are stored as plain text separated by double newline characters.
  * The transformed output is intended for the Healthie (destination) system, which expects
  * Unicode-escaped HTML strings for proper rendering of text content.
+ * 
+ * IMPORTANT: When Sending data to Healthie they expect HTML-encoded multiline text
+ * Like this: "<p>Some long text I have in here</p>\n<p>With new lines</p>" - they then do their own logic for displaying it
  *
  * @param text - The plain text input from Awell where paragraphs are separated by double newline characters.
  * @returns {Object} An object containing both the normal HTML and the Unicode escaped HTML string.


### PR DESCRIPTION
### **User description**
Healthie is expecting HTML-encoded multiline text when sending a textarea form answer


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed the format of long text answers to use plain HTML instead of Unicode-escaped HTML.
- Updated test cases to reflect the change in long text answer format.
- Added documentation to clarify the expected HTML format for Healthie integration.
- Updated package version to 0.1.17.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>awellFormResponseToHealthieFormAnswers.test.ts</strong><dd><code>Update test case for long text answer format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/awellFormResponseToHealthieFormAnswers.test.ts

- Updated test case to use HTML instead of Unicode-escaped HTML.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-sdk/pull/2/files#diff-639b2cb746a8654a0fb034b2fcdb2f3bef31243ea56c8847e99e931580797088">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>awellFormResponseToHealthieFormAnswers.ts</strong><dd><code>Fix long text answer format to plain HTML</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/awellFormResponseToHealthieFormAnswers.ts

<li>Changed the return value from Unicode-escaped HTML to plain HTML for <br>long text answers.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-sdk/pull/2/files#diff-e5be1daab521c3f81da01c9f83d4fd010750bc2cecfd3b4cc4a7fea0cef2f44c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getLongTextAnswer.ts</strong><dd><code>Document expected HTML format for Healthie integration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/utils/healthie/awellFormResponseToHealthieFormAnswers/utils/getLongTextAnswer/getLongTextAnswer.ts

- Added clarification on the expected HTML format for Healthie.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-sdk/pull/2/files#diff-911e47b4fbeaa8e03fd82a9714a50ff930383e37d9024662863bea639edf9399">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update package version to 0.1.17</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bumped package version from 0.1.16 to 0.1.17.



</details>


  </td>
  <td><a href="https://github.com/awell-health/awell-sdk/pull/2/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information