### PR TITLE
chore: bump version to 0.1.32 to publish the #17 security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/awell-sdk",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "packageManager": "yarn@4.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps `version` to **0.1.32** so the security fixes merged in #17 can actually publish.

## Why this is needed

#17 merged cleanly — `Build and test` passed on `main` — but the `Compile and publish package` workflow then failed:

```
YN0035: You cannot publish over the previously published versions: 0.1.31.
  Response Code: 403 (Forbidden)
```

`release.yml` publishes whatever `package.json` declares (`yarn version "$pkg_version"` then `yarn npm publish`). It does **not** derive or increment the version. Unlike the extension repos and `extensions-core` — which carry a `version-bump.yml` / `version-bump-on-push.yml` workflow — this repo has only `build-and-test.yml`, `pr-agent.yml` and `release.yml`, so **the version has to be bumped by hand in any PR that should publish.** #17 did not do that, which is my omission.

Nothing is wrong with the code on `main`; it is only unpublished.

## What this unblocks

Until 0.1.32 is on npm, none of #17's fixes reach any consumer, because every consumer resolves `awell-sdk` from its own lockfile:

- **`@genql/cli` moved out of `dependencies`** — the change that removes the `undici` subtree from `awell-extension-server`, `awell-extensions`, `extension-azjp` and `extension-wellpath`
- **`crypto` (npm's deprecated placeholder) removed**, and `src/webhooks/verify.ts` switched to `node:crypto`
- `undici` 8.3.0 → 8.10.0 (5 high, one at severity 86), `ws` 8.18.0 → 8.21.3 (2 high), `brace-expansion` → 1.1.18/2.1.4 (1 high), `form-data` out of the tree

Consumers declare `^0.1.31` (the server declares `^0.1.30`), so 0.1.32 is in range everywhere — but each repo still needs its lockfile re-resolved to pick it up. That is a separate follow-up per repo.

## Risk

**Very low.** A single-field version change. No dependency, lockfile-resolution or source change; `yarn install` reports only `package.json` as modified.

| Risk | Verdict |
| --- | --- |
| Publishing something unintended | **Resolved.** `main` already contains exactly what #17 reviewed and CI approved; this only makes it publishable. Confirmed the merged `node:crypto` change is present on `main`. |
| Wrong version increment | **Resolved.** 0.1.31 → 0.1.32, a patch bump. The change is a dependency/security fix with no API change: `src/index.ts` exports are untouched, so no consumer needs a code change. |
| Republishing over an existing version | **Resolved.** 0.1.32 does not exist on npm; 0.1.31 is the current latest. |

## Verification

| | result |
| --- | --- |
| `yarn install` | pass — only `package.json` modified |
| `yarn build` | pass |
| `yarn lint` | **fail** — pre-existing on `main`, unchanged |
| `yarn test` | pass |

## Worth fixing separately

This repo should get the same `version-bump` workflow the extension repos and `extensions-core` already have. Every future PR here has the same trap: green CI on the PR, then a silent 403 on `main` that only shows up in the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
